### PR TITLE
Updating to match MongoDB v2 driver

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mongodb-gridfs"
 license = "MIT"
-version = "0.1.2"
+version = "0.2.0"
 authors = ["Moïse Valvassori <moise.valvassori@gmail.com>"]
 edition = "2018"
 description = "An implementation of Mongo GridFS"
@@ -11,15 +11,15 @@ repository = "https://github.com/djedi23/mongodb-gridfs-rs"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-mongodb = { version="1.1", default-features = false}
-bson = {version= "1.1" }
-md-5 = "0.8.0"
+mongodb = { version = "2.0.0-beta.3", default-features=false, features=["bson-u2i", "bson-chrono-0_4", "bson-uuid-0_8"] }
+bson = {version= "2.0.0-beta.3", features=["u2i"]}
+md-5 = "0.9.1"
 futures = "0.3.5"
 typed-builder = "0.9.0"
 chrono = "0.4"
 
 [dev-dependencies]
-tokio = { version="0.2.25", features=["macros"]}
+tokio = { version="1.9.0", features=["test-util"]}
 uuid = "0.8.2"
 
 [features]

--- a/src/bucket/delete.rs
+++ b/src/bucket/delete.rs
@@ -1,5 +1,5 @@
 use crate::{bucket::GridFSBucket, GridFSError};
-use bson::{doc, oid::ObjectId};
+use bson::{doc, oid::ObjectId, Document};
 use mongodb::options::DeleteOptions;
 
 impl GridFSBucket {
@@ -50,9 +50,9 @@ impl GridFSBucket {
         let dboptions = self.options.clone().unwrap_or_default();
         let bucket_name = dboptions.bucket_name;
         let file_collection = bucket_name.clone() + ".files";
-        let files = self.db.collection(&file_collection);
+        let files = self.db.collection::<Document>(&file_collection);
         let chunk_collection = bucket_name + ".chunks";
-        let chunks = self.db.collection(&chunk_collection);
+        let chunks = self.db.collection::<Document>(&chunk_collection);
 
         let mut delete_option = DeleteOptions::default();
         if let Some(write_concern) = dboptions.write_concern.clone() {
@@ -82,6 +82,7 @@ mod tests {
     use crate::{options::GridFSBucketOptions, GridFSError};
     use bson::doc;
     use bson::oid::ObjectId;
+    use bson::Document;
     use mongodb::Client;
     use mongodb::Database;
     use uuid::Uuid;
@@ -111,13 +112,13 @@ mod tests {
         bucket.delete(id.clone()).await?;
 
         let count = db
-            .collection("fs.files")
+            .collection::<Document>("fs.files")
             .count_documents(doc! { "_id": id.clone() }, None)
             .await?;
         assert_eq!(count, 0, "File should be deleted");
 
         let count = db
-            .collection("fs.chunks")
+            .collection::<Document>("fs.chunks")
             .count_documents(doc! { "files_id": id }, None)
             .await?;
         assert_eq!(count, 0, "Chunks should be deleted");
@@ -141,13 +142,13 @@ mod tests {
         assert!(result.is_err());
 
         let count = db
-            .collection("fs.files")
+            .collection::<Document>("fs.files")
             .count_documents(doc! { "_id": id.clone() }, None)
             .await?;
         assert_eq!(count, 0, "File should be deleted");
 
         let count = db
-            .collection("fs.chunks")
+            .collection::<Document>("fs.chunks")
             .count_documents(doc! { "files_id": id }, None)
             .await?;
         assert_eq!(count, 0, "Chunks should be deleted");

--- a/src/bucket/download.rs
+++ b/src/bucket/download.rs
@@ -1,5 +1,5 @@
 use crate::{bucket::GridFSBucket, GridFSError};
-use bson::{doc, oid::ObjectId};
+use bson::{doc, oid::ObjectId, Document};
 use futures::{Stream, StreamExt};
 use mongodb::options::{FindOneOptions, FindOptions, SelectionCriteria};
 
@@ -61,9 +61,9 @@ impl GridFSBucket {
         let dboptions = self.options.clone().unwrap_or_default();
         let bucket_name = dboptions.bucket_name;
         let file_collection = bucket_name.clone() + ".files";
-        let files = self.db.collection(&file_collection);
+        let files = self.db.collection::<Document>(&file_collection);
         let chunk_collection = bucket_name + ".chunks";
-        let chunks = self.db.collection(&chunk_collection);
+        let chunks = self.db.collection::<Document>(&chunk_collection);
 
         let mut find_one_options = FindOneOptions::default();
         let mut find_options = FindOptions::builder().sort(doc! {"n":1}).build();

--- a/src/bucket/drop.rs
+++ b/src/bucket/drop.rs
@@ -1,5 +1,6 @@
 use crate::bucket::GridFSBucket;
 use mongodb::error::Result;
+use bson::Document;
 
 impl GridFSBucket {
     /**
@@ -11,7 +12,7 @@ impl GridFSBucket {
         let dboptions = self.options.clone().unwrap_or_default();
         let bucket_name = dboptions.bucket_name;
         let file_collection = bucket_name.clone() + ".files";
-        let files = self.db.collection(&file_collection);
+        let files = self.db.collection::<Document>(&file_collection);
 
         // let drop_options = DropCollectionOptions::builder()
         //     .write_concern(dboptions.write_concern.clone())
@@ -21,7 +22,7 @@ impl GridFSBucket {
         files.drop(None).await?;
 
         let chunk_collection = bucket_name + ".chunks";
-        let chunks = self.db.collection(&chunk_collection);
+        let chunks = self.db.collection::<Document>(&chunk_collection);
 
         //        let drop_options = DropCollectionOptions::default(); //  builder()
         // .write_concern(dboptions.write_concern)

--- a/src/bucket/find.rs
+++ b/src/bucket/find.rs
@@ -39,11 +39,11 @@ impl GridFSBucket {
     # }
     ```
      */
-    pub async fn find(&self, filter: Document, options: GridFSFindOptions) -> Result<Cursor> {
+    pub async fn find(&self, filter: Document, options: GridFSFindOptions) -> Result<Cursor<Document>> {
         let dboptions = self.options.clone().unwrap_or_default();
         let bucket_name = dboptions.bucket_name;
         let file_collection = bucket_name + ".files";
-        let files = self.db.collection(&file_collection);
+        let files = self.db.collection::<Document>(&file_collection);
 
         let find_options = FindOptions::builder()
             .allow_disk_use(options.allow_disk_use)

--- a/src/bucket/rename.rs
+++ b/src/bucket/rename.rs
@@ -1,5 +1,5 @@
 use crate::bucket::GridFSBucket;
-use bson::{doc, oid::ObjectId};
+use bson::{doc, oid::ObjectId, Document};
 use mongodb::{error::Result, options::UpdateOptions, results::UpdateResult};
 
 impl GridFSBucket {
@@ -12,7 +12,7 @@ impl GridFSBucket {
         let dboptions = self.options.clone().unwrap_or_default();
         let bucket_name = dboptions.bucket_name;
         let file_collection = bucket_name + ".files";
-        let files = self.db.collection(&file_collection);
+        let files = self.db.collection::<Document>(&file_collection);
 
         let update_options = UpdateOptions::builder()
             .write_concern(dboptions.write_concern)
@@ -33,6 +33,7 @@ mod tests {
     use super::GridFSBucket;
     use crate::{options::GridFSBucketOptions, GridFSError};
     use bson::doc;
+    use bson::Document;
     use mongodb::Client;
     use mongodb::Database;
     use uuid::Uuid;
@@ -62,7 +63,7 @@ mod tests {
         bucket.rename(id.clone(), "renamed_file.txt").await?;
 
         let file = db
-            .collection("fs.files")
+            .collection::<Document>("fs.files")
             .find_one(doc! { "_id": id }, None)
             .await?
             .unwrap();

--- a/src/bucket/upload.rs
+++ b/src/bucket/upload.rs
@@ -220,7 +220,7 @@ impl GridFSBucket {
         mut self,
         filename: &str,
         mut source: impl Read,
-        options: Option<GridFSUploadOptions<'a>>,
+        options: Option<GridFSUploadOptions>,
     ) -> Result<ObjectId, Error> {
         let dboptions = self.options.clone().unwrap_or_default();
         let mut chunk_size: u32 = dboptions.chunk_size_bytes;
@@ -281,7 +281,7 @@ impl GridFSBucket {
                 .await?;
             length += read_size;
             n += 1;
-            if let Some(progress_tick) = progress_tick {
+            if let Some(ref progress_tick) = progress_tick {
                 progress_tick.update(length);
             };
         }

--- a/src/bucket/upload.rs
+++ b/src/bucket/upload.rs
@@ -8,6 +8,7 @@ use mongodb::{
     options::{FindOneOptions, InsertOneOptions, UpdateOptions},
     Collection,
 };
+use futures::StreamExt;
 use std::io::Read;
 
 impl GridFSBucket {
@@ -51,7 +52,7 @@ impl GridFSBucket {
     /// [Spec](https://github.com/mongodb/specifications/blob/master/source/gridfs/gridfs-spec.rst#before-write-operations)
     async fn ensure_file_index(
         &mut self,
-        files: &Collection,
+        files: &Collection<Document>,
         file_collection: &str,
         chunk_collection: &str,
     ) -> Result<(), Error> {
@@ -269,7 +270,7 @@ impl GridFSBucket {
             }
             let mut bin: Vec<u8> = Vec::from(buffer);
             bin.resize(read_size, 0);
-            md5.input(&bin);
+            md5.update(&bin);
             chunks
                 .insert_one(
                     doc! {"files_id":files_id,
@@ -285,9 +286,9 @@ impl GridFSBucket {
             };
         }
 
-        let mut update = doc! { "length": length as u64, "uploadDate": Utc::now() };
+        let mut update = doc! { "length": length as i64, "uploadDate": Utc::now() };
         if !disable_md5 {
-            update.insert("md5", format!("{:02x}", md5.result()));
+            update.insert("md5", format!("{:02x}", md5.finalize()));
         }
         let mut update_option = UpdateOptions::default();
         if let Some(write_concern) = dboptions.write_concern {
@@ -312,7 +313,7 @@ mod tests {
     use bson::{doc, Document};
     use mongodb::Client;
     use mongodb::{error::Error, Database};
-    use tokio::stream::StreamExt;
+    use futures::StreamExt;
     use uuid::Uuid;
     fn db_name_new() -> String {
         "test_".to_owned()
@@ -336,7 +337,7 @@ mod tests {
 
         assert_eq!(id.to_hex(), id.to_hex());
         let file = db
-            .collection("fs.files")
+            .collection::<Document>("fs.files")
             .find_one(doc! { "_id": id.clone() }, None)
             .await?
             .unwrap();
@@ -387,7 +388,7 @@ mod tests {
 
         assert_eq!(id.to_hex(), id.to_hex());
         let file = db
-            .collection("fs.files")
+            .collection::<Document>("fs.files")
             .find_one(doc! { "_id": id.clone() }, None)
             .await?
             .unwrap();
@@ -400,7 +401,7 @@ mod tests {
         );
 
         let chunks: Vec<Result<Document, Error>> = db
-            .collection("fs.chunks")
+            .collection::<Document>("fs.chunks")
             .find(doc! { "files_id": id }, None)
             .await?
             .collect()

--- a/src/options.rs
+++ b/src/options.rs
@@ -1,6 +1,6 @@
 use bson::Document;
 use mongodb::options::{ReadConcern, ReadPreference, WriteConcern};
-use std::time::Duration;
+use std::{sync::Arc, time::Duration};
 use typed_builder::TypedBuilder;
 
 // TODO: rethink the name of the trait
@@ -11,7 +11,7 @@ pub trait ProgressUpdate {
 
 /// [Spec](https://github.com/mongodb/specifications/blob/master/source/gridfs/gridfs-spec.rst#file-upload)
 #[derive(Clone, Default, TypedBuilder)]
-pub struct GridFSUploadOptions<'a> {
+pub struct GridFSUploadOptions {
     /**
      * The number of bytes per chunk of this file. Defaults to the
      * chunkSizeBytes in the GridFSBucketOptions.
@@ -52,7 +52,7 @@ pub struct GridFSUploadOptions<'a> {
      */
     // TODO: find a better name.
     #[builder(default = None)]
-    pub(crate) progress_tick: Option<&'a dyn ProgressUpdate>, // TODO: test process_tick
+    pub(crate) progress_tick: Option<Arc<dyn ProgressUpdate + Send + Sync>>, // TODO: test process_tick
 }
 
 /// [Spec](https://github.com/mongodb/specifications/blob/master/source/gridfs/gridfs-spec.rst#configurable-gridfsbucket-class)

--- a/src/options.rs
+++ b/src/options.rs
@@ -157,7 +157,7 @@ pub struct GridFSFindOptions {
      * The number of documents to skip before returning.
      */
     #[builder(default)]
-    pub skip: i64,
+    pub skip: u64,
 
     /**
      * The order by which to sort results. Defaults to not sorting.


### PR DESCRIPTION
V2 of the MongoDB driver has made some big changes in terms of type safety. There could be some changes to make a GridFS-specific `Document` type but this builds and passes tests for now.