### PR TITLE
Some updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ From https://github.com/mongodb/specifications/blob/master/source/gridfs/gridfs-
 Uploading a document:
  ```rust
  use mongodb_gridfs::{options::GridFSBucketOptions, GridFSBucket};
- let bucket = GridFSBucket::new(db.clone(), Some(GridFSBucketOptions::default()));
+ let mut bucket = GridFSBucket::new(db.clone(), Some(GridFSBucketOptions::default()));
  let id = bucket
      .upload_from_stream("test.txt", "stream your data here".as_bytes(), None)
      .await?;

--- a/examples/upload.rs
+++ b/examples/upload.rs
@@ -18,7 +18,7 @@ async fn main() -> Result<(), Error> {
     .await?;
     let dbname = db_name_new();
     let db: Database = client.database(&dbname);
-    let bucket = GridFSBucket::new(db.clone(), Some(GridFSBucketOptions::default()));
+    let mut bucket = GridFSBucket::new(db.clone(), Some(GridFSBucketOptions::default()));
     let id = bucket
         .upload_from_stream("test.txt", "test data".as_bytes(), None)
         .await?;

--- a/src/bucket/download.rs
+++ b/src/bucket/download.rs
@@ -1,9 +1,111 @@
 use crate::{bucket::GridFSBucket, GridFSError};
 use bson::{doc, oid::ObjectId, Document};
-use futures::{Stream, StreamExt};
+use futures::{Stream, StreamExt, TryFutureExt};
 use mongodb::options::{FindOneOptions, FindOptions, SelectionCriteria};
 
 impl GridFSBucket {
+    /// Opens a Stream from which the application can read the contents of the stored file
+    /// specified by @id.
+    /// [Spec](https://github.com/mongodb/specifications/blob/master/source/gridfs/gridfs-spec.rst#file-download)
+    /// 
+    /// Returns a [`Stream`].
+    /// 
+    /// # Examples
+    /// 
+    ///  ```rust
+    ///  use futures::stream::StreamExt;
+    ///  # use mongodb::Client;
+    ///  # use mongodb::Database;
+    ///  use mongodb_gridfs::{options::GridFSBucketOptions, GridFSBucket, GridFSError};
+    ///  # use uuid::Uuid;
+    ///  # fn db_name_new() -> String {
+    ///  #     "test_".to_owned()
+    ///  #         + Uuid::new_v4()
+    ///  #             .to_hyphenated()
+    ///  #             .encode_lower(&mut Uuid::encode_buffer())
+    ///  # }
+    ///  #
+    ///  # #[tokio::main]
+    ///  # async fn main() -> Result<(), GridFSError> {
+    ///  #     let client = Client::with_uri_str(
+    ///  #         &std::env::var("MONGO_URI").unwrap_or("mongodb://localhost:27017/".to_string()),
+    ///  #     )
+    ///  #     .await?;
+    ///  #     let dbname = db_name_new();
+    ///  #     let db: Database = client.database(&dbname);
+    ///  let bucket = GridFSBucket::new(db.clone(), Some(GridFSBucketOptions::default()));
+    ///  #     let id = bucket
+    ///  #         .clone()
+    ///  #         .upload_from_stream("test.txt", "test data".as_bytes(), None)
+    ///  #         .await?;
+    ///  #     println!("{}", id);
+    ///  #
+    ///  let (mut cursor, filename) = bucket.open_download_stream_with_filename(id).await?;
+    ///  assert_eq!(filename, "test.txt");
+    ///  let buffer = cursor.next().await.unwrap();
+    ///  #     println!("{:?}", buffer);
+    ///  #
+    ///  #     db.drop(None).await?;
+    ///  #     Ok(())
+    ///  # }
+    ///  ```
+    /// 
+    ///  # Errors
+    /// 
+    ///  Raise [`GridFSError::FileNotFound`] when the requested id doesn't exists.
+    ///
+    pub async fn open_download_stream_with_filename(
+        &self,
+        id: ObjectId,
+    ) -> Result<(impl Stream<Item = Vec<u8>>, String), GridFSError> {
+        let dboptions = self.options.clone().unwrap_or_default();
+        let bucket_name = dboptions.bucket_name;
+        let file_collection = bucket_name.clone() + ".files";
+        let files = self.db.collection::<Document>(&file_collection);
+        let chunk_collection = bucket_name + ".chunks";
+        let chunks = self.db.collection::<Document>(&chunk_collection);
+
+        let mut find_one_options = FindOneOptions::default();
+        let mut find_options = FindOptions::builder().sort(doc! {"n":1}).build();
+
+        if let Some(read_concern) = dboptions.read_concern {
+            find_one_options.read_concern = Some(read_concern.clone());
+            find_options.read_concern = Some(read_concern);
+        }
+        if let Some(read_preference) = dboptions.read_preference {
+            find_one_options.selection_criteria =
+                Some(SelectionCriteria::ReadPreference(read_preference.clone()));
+            find_options.selection_criteria =
+                Some(SelectionCriteria::ReadPreference(read_preference));
+        }
+
+        /*
+        Drivers must first retrieve the files collection document for this
+        file. If there is no files collection document, the file either never
+        existed, is in the process of being deleted, or has been corrupted,
+        and the driver MUST raise an error.
+        */
+        let file = files
+            .find_one(doc! {"_id":id.clone()}, find_one_options)
+            .await?;
+
+        if let Some(file) = file {
+            let filename = file.get_str("filename").unwrap().to_string();
+            let stream =
+            chunks
+                .find(doc! {"files_id":id}, find_options.clone())
+                .await
+                .unwrap()
+                .map(|item| {
+                    let i = item.unwrap();
+                    i.get_binary_generic("data").unwrap().clone()
+                });
+            Ok((stream, filename))
+        } else {
+            Err(GridFSError::FileNotFound())
+        }
+    }
+
     /**
      Opens a Stream from which the application can read the contents of the stored file
      specified by @id.
@@ -58,49 +160,7 @@ impl GridFSBucket {
         &self,
         id: ObjectId,
     ) -> Result<impl Stream<Item = Vec<u8>>, GridFSError> {
-        let dboptions = self.options.clone().unwrap_or_default();
-        let bucket_name = dboptions.bucket_name;
-        let file_collection = bucket_name.clone() + ".files";
-        let files = self.db.collection::<Document>(&file_collection);
-        let chunk_collection = bucket_name + ".chunks";
-        let chunks = self.db.collection::<Document>(&chunk_collection);
-
-        let mut find_one_options = FindOneOptions::default();
-        let mut find_options = FindOptions::builder().sort(doc! {"n":1}).build();
-
-        if let Some(read_concern) = dboptions.read_concern {
-            find_one_options.read_concern = Some(read_concern.clone());
-            find_options.read_concern = Some(read_concern);
-        }
-        if let Some(read_preference) = dboptions.read_preference {
-            find_one_options.selection_criteria =
-                Some(SelectionCriteria::ReadPreference(read_preference.clone()));
-            find_options.selection_criteria =
-                Some(SelectionCriteria::ReadPreference(read_preference));
-        }
-
-        /*
-        Drivers must first retrieve the files collection document for this
-        file. If there is no files collection document, the file either never
-        existed, is in the process of being deleted, or has been corrupted,
-        and the driver MUST raise an error.
-        */
-        let file = files
-            .find_one(doc! {"_id":id.clone()}, find_one_options)
-            .await?;
-
-        if file.is_none() {
-            return Err(GridFSError::FileNotFound());
-        }
-
-        Ok(chunks
-            .find(doc! {"files_id":id}, find_options.clone())
-            .await
-            .unwrap()
-            .map(|item| {
-                let i = item.unwrap();
-                i.get_binary_generic("data").unwrap().clone()
-            }))
+        self.open_download_stream_with_filename(id).map_ok(|(stream, _)| stream).await
     }
 }
 


### PR DESCRIPTION
Thanks for this wonderful gridfs implementation on the official driver! When I use this crate, I make some changes on code to make myself comfortable. I think these changes may be acceptable for other user:
1. In the `bucket.upload_from_stream()` method, `mut self` is moved, not borrowed, which means user cannot reuse `bucket` after calling the method. I change `self` to `&mut self`. Fortunately, no more codes in that method should be modified. Of course, the `mut` identifier should be added before `bucket` in test cases.
2. The type of `source` argument in `bucket.upload_from_stream()` is `impl std::io::Read`, which is sync. I change the type to `impl futures::io::AsyncRead + Unpin` to enable async reading of `source`. `&[u8]` has implemented `AsyncRead + Unpin`, so the examples and test cases should work without modification.
3. In my case, I want to know the filename when I download a file from gridfs. I adapt a new `open_download_stream_with_filename` to return stream along with filename. 

These changes are tested with my cases.