### PR TITLE
Fix the bug of inconsistent uploaded chunk size

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -10,13 +10,61 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  build:
-
+  check:
+    name: Check
     runs-on: ubuntu-latest
-
     steps:
-    - uses: actions/checkout@v2
-    - name: Build
-      run: cargo build --verbose
-    - name: Run tests
-      run: cargo test --verbose
+      - name: Checkout sources
+        uses: actions/checkout@v3
+
+      - name: Install stable toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
+
+      - name: Run cargo check
+        run: cargo check
+
+  test:
+    name: Build&Test Suite
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v3
+
+      - name: Install stable toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
+
+      - name: Launch docker containers for testing
+        run: |
+          docker pull mongo:latest
+          docker run --rm -d -p 27017:27017 mongo:latest
+
+      - name: Run cargo build
+        run: cargo build --verbose
+
+      - name: Run cargo test
+        run: cargo test --verbose
+    env:
+      RUST_BACKTRACE: 1
+
+  lints:
+    name: Lints
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v3
+
+      - name: Install stable toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
+          components: rustfmt, clippy
+
+      - name: Run cargo fmt
+        run: cargo fmt --all -- --check
+
+      - name: Run cargo clippy
+        run: cargo clippy -- -D warnings

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -947,6 +947,7 @@ dependencies = [
  "futures",
  "md-5",
  "mongodb",
+ "tempfile",
  "tokio",
  "tokio-stream",
  "typed-builder",
@@ -1135,6 +1136,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
 dependencies = [
  "bitflags",
+]
+
+[[package]]
+name = "remove_dir_all"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]
@@ -1418,6 +1428,20 @@ name = "take_mut"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f764005d11ee5f36500a149ace24e00e3da98b0158b3e2d53a7495660d3f4d60"
+
+[[package]]
+name = "tempfile"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cdb1ef4eaeeaddc8fbd371e5017057064af0911902ef36b39801f67cc6d79e4"
+dependencies = [
+ "cfg-if",
+ "fastrand",
+ "libc",
+ "redox_syscall",
+ "remove_dir_all",
+ "winapi",
+]
 
 [[package]]
 name = "termcolor"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -940,7 +940,7 @@ dependencies = [
 
 [[package]]
 name = "mongodb-gridfs"
-version = "0.2.3"
+version = "0.2.3-patched"
 dependencies = [
  "bson",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,8 @@ tokio = { version="1", optional=true}
 tokio-stream = { version="0.1", optional=true}
 
 [dev-dependencies]
-tokio = { version="1", features=["test-util"]}
+tempfile = "3.3.0"
+tokio = { version="1", features=["fs", "test-util"]}
 uuid = "0.8"
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mongodb-gridfs"
 license = "MIT"
-version = "0.2.3"
+version = "0.2.3-patched"
 authors = ["Moïse Valvassori <moise.valvassori@gmail.com>"]
 edition = "2018"
 description = "An implementation of Mongo GridFS"


### PR DESCRIPTION
This pr was proposed to address #6 by looping the reads until either fulfilling the chunk buffer or reaching the end of file.

Additionally, this pr also rephrases .github/workflows/rust.yml so that the automated testing could be run successfully.

In summary, the changelog is
- brings the workflow defined in .github/workflows/rust.yml back to work
- add cases for testing upload_from_stream with tokio::fs::File
- fix the broken uploading logic of upload_from_stream